### PR TITLE
[CE-726] - Change methodology name from Api Testing to API Testing

### DIFF
--- a/methodologies/api_testing.json
+++ b/methodologies/api_testing.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Api Testing",
+    "title": "API Testing",
     "release_date": "2023-03-31T00:00:00+00:00",
     "description": "Bugcrowd api methodology testing",
     "vrt_version": "10.0.1"


### PR DESCRIPTION
### User story

- As a TPM, I am able to select API as a methodology for Classic Pen Test. 
- As a researcher, the API methodology is shown to me if the engagement type is an API
- As a customer, I can see the API methodology when the engagement type is an API
methodology document: https://docs.google.com/document/d/1si7s9WS5ZSzMkEvv8FAVv9oIRYyf-cN_D-i8u1PdxXU/edit

- Jira: CE-726

### Technical Explanation
- Changed the title of api testing.

### To Test:
Content must reflect what we have in the methodology document.
